### PR TITLE
Add background service that runs the scheduling algorithm

### DIFF
--- a/backend/src/data_model/graph.rs
+++ b/backend/src/data_model/graph.rs
@@ -7,7 +7,6 @@ pub struct DiscreteGraph {
 }
 
 impl DiscreteGraph {
-    #[allow(dead_code)] // Used in the test for the scheduler, but clippy does #?%!
     pub fn new(values: Vec<f64>, time_delta: Duration, start_time: DateTimeUtc) -> DiscreteGraph {
         DiscreteGraph {
             values,

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -6,22 +6,22 @@ use axum::{
 use protocol::accounts::AuthToken;
 use sqlx::SqlitePool;
 
-use crate::data_model::account::AccountId;
+use crate::{data_model::account::AccountId, MyState};
 
 // Account id
 pub struct Authentication(pub AccountId);
 
 #[async_trait]
-impl FromRequestParts<SqlitePool> for Authentication {
+impl FromRequestParts<MyState> for Authentication {
     type Rejection = (StatusCode, String);
 
     async fn from_request_parts(
         parts: &mut Parts,
-        pool: &SqlitePool,
+        state: &MyState,
     ) -> Result<Self, Self::Rejection> {
         match get_auth_token(&parts.headers) {
             Some(token) => {
-                if let Some(account_id) = get_account_id_from_token(token, pool).await {
+                if let Some(account_id) = get_account_id_from_token(token, &state.pool).await {
                     Ok(Authentication(account_id))
                 } else {
                     Err((

--- a/backend/src/handlers/events.rs
+++ b/backend/src/handlers/events.rs
@@ -4,13 +4,12 @@ use protocol::{
     events::{Event, EventId, GetDeviceEventsRequest, GetEventsResponse},
     tasks::TaskId,
 };
-use sqlx::SqlitePool;
 
-use crate::{extractors::auth::Authentication, handlers::util::internal_error};
+use crate::{extractors::auth::Authentication, handlers::util::internal_error, MyState};
 
 #[debug_handler]
 pub async fn get_all_events(
-    State(pool): State<SqlitePool>,
+    State(state): State<MyState>,
     Authentication(account_id): Authentication,
 ) -> Result<Json<GetEventsResponse>, (StatusCode, String)> {
     let events = sqlx::query!(
@@ -23,7 +22,7 @@ pub async fn get_all_events(
         "#,
         account_id
     )
-    .fetch_all(&pool)
+    .fetch_all(&state.pool)
     .await
     .map_err(internal_error)?;
 
@@ -41,7 +40,7 @@ pub async fn get_all_events(
 
 #[debug_handler]
 pub async fn get_device_events(
-    State(pool): State<SqlitePool>,
+    State(state): State<MyState>,
     Authentication(account_id): Authentication,
     Json(get_device_event_request): Json<GetDeviceEventsRequest>,
 ) -> Result<Json<GetEventsResponse>, (StatusCode, String)> {
@@ -56,7 +55,7 @@ pub async fn get_device_events(
         account_id,
         get_device_event_request.device_id
     )
-    .fetch_all(&pool)
+    .fetch_all(&state.pool)
     .await
     .map_err(internal_error)?;
 

--- a/backend/src/scheduling.rs
+++ b/backend/src/scheduling.rs
@@ -1,3 +1,4 @@
+pub mod background_service;
 pub mod event_creation;
-mod scheduler;
+pub mod scheduler;
 pub mod unpublished_event;

--- a/backend/src/scheduling/background_service.rs
+++ b/backend/src/scheduling/background_service.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::{TimeDelta, Utc};
+use protocol::{
+    devices::DeviceId,
+    tasks::{Task, TaskId},
+    time::{Milliseconds, Timespan},
+};
+use sqlx::SqlitePool;
+use tokio::{select, sync::mpsc::UnboundedReceiver, time::sleep};
+
+use crate::data_model::graph::DiscreteGraph;
+
+use super::scheduler::SchedulerAlgorithm;
+
+pub async fn background_service<F, TAlg>(
+    mut receiver: UnboundedReceiver<()>,
+    pool: SqlitePool,
+    algorithm_constructor: F,
+) where
+    F: FnOnce() -> TAlg,
+    TAlg: SchedulerAlgorithm,
+{
+    let mut algorithm = algorithm_constructor();
+    loop {
+        // Wait until we receive a message.
+        let msg = receiver.recv().await;
+        if msg.is_none() {
+            break;
+        }
+
+        let debounce = sleep(Duration::from_secs(5 * 60));
+
+        select! {
+            _ = debounce => {
+                if let Err(error) = run_algorithm(&pool, &mut algorithm).await {
+                    println!("Algorithm error!: {}", error);
+                }
+            }
+            msg = receiver.recv() => {
+                if msg.is_none() {
+                    break;
+                }
+            }
+        };
+    }
+}
+
+async fn run_algorithm(pool: &SqlitePool, algorithm: &mut impl SchedulerAlgorithm) -> Result<()> {
+    // TODO: Filter out tasks based on time
+    // TODO: Filter out tasks that have a started event
+    let tasks = sqlx::query!(
+        r#"
+        SELECT id as "id: TaskId", timespan_start, timespan_end, duration as "duration: Milliseconds", device_id as "device_id: DeviceId"
+        FROM Tasks
+        "#)
+        .fetch_all(pool)
+        .await?;
+
+    let tasks = tasks
+        .iter()
+        .map(|t| Task {
+            id: t.id,
+            timespan: Timespan::new_from_naive(t.timespan_start, t.timespan_end),
+            duration: t.duration,
+            device_id: t.device_id,
+        })
+        .collect();
+
+    let values = vec![
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 28.0, 200.0, 484.0, 829.0, 1186.0, 1407.0, 1475.0, 1455.0,
+        1393.0, 1271.0, 1044.0, 754.0, 445.0, 154.0, 10.0, 0.0, 0.0, 0.0,
+    ];
+
+    let graph = DiscreteGraph::new(values, TimeDelta::hours(1), Utc::now());
+
+    let events = algorithm.schedule(graph, tasks)?;
+
+    // TODO: Save events (db or hashmap?)
+    events.iter().for_each(|e| {
+        println!("Event task: {}, start: {}", e.task_id, e.start_time);
+    });
+
+    Ok(())
+}

--- a/backend/src/scheduling/unpublished_event.rs
+++ b/backend/src/scheduling/unpublished_event.rs
@@ -1,7 +1,7 @@
 use protocol::{tasks::TaskId, time::DateTimeUtc};
 
 #[derive(PartialEq, Debug)]
-pub struct UnPublishedEvent {
+pub struct UnpublishedEvent {
     pub task_id: TaskId,
     pub start_time: DateTimeUtc,
 }


### PR DESCRIPTION
This service runs in the background, and runs the scheduling algorithm, when tasks has changed.
This happens in the following conditions:
- Deleting a device
- Deleting a task
- Creating a task

After one of these things happen a timer is started on the background service.
This timer is set to 5 minutes.
After 5 minutes it runs the algorithm.
This is done to make sure that it takes at least 5 minutes between runs of the algorithm, while only running the algorithm when something has changed.

This also fixes some small off-by-one issues in the NaiveScheduler.

Closes #13 