### PR TITLE
Device event endpoint returns one event now

### DIFF
--- a/backend/src/handlers/events.rs
+++ b/backend/src/handlers/events.rs
@@ -1,7 +1,7 @@
 use axum::{debug_handler, extract::State, http::StatusCode, Json};
 use chrono::{TimeZone, Utc};
 use protocol::{
-    events::{Event, EventId, GetDeviceEventsRequest, GetEventsResponse},
+    events::{Event, EventId, GetDeviceEventRequest, GetEventResponse, GetEventsResponse},
     tasks::TaskId,
 };
 
@@ -39,34 +39,34 @@ pub async fn get_all_events(
 }
 
 #[debug_handler]
-pub async fn get_device_events(
+pub async fn get_device_event(
     State(state): State<MyState>,
     Authentication(account_id): Authentication,
-    Json(get_device_event_request): Json<GetDeviceEventsRequest>,
-) -> Result<Json<GetEventsResponse>, (StatusCode, String)> {
-    let events = sqlx::query!(
+    Json(get_device_event_request): Json<GetDeviceEventRequest>,
+) -> Result<Json<GetEventResponse>, (StatusCode, String)> {
+    let current_time = Utc::now();
+    let event = sqlx::query!(
         r#"
         SELECT Events.id as "id: EventId", Events.task_id as "task_id: TaskId", Events.start_time
         FROM Events 
         JOIN Tasks ON Events.task_id == Tasks.id 
         JOIN Devices ON Tasks.device_id == Devices.id
-        WHERE Devices.account_id = ? AND Devices.id = ?
+        WHERE Devices.account_id = ? AND Devices.id = ? AND Events.start_time >= ?
+        LIMIT 1
         "#,
         account_id,
-        get_device_event_request.device_id
+        get_device_event_request.device_id,
+        current_time
     )
-    .fetch_all(&state.pool)
+    .fetch_optional(&state.pool)
     .await
     .map_err(internal_error)?;
 
-    let events = events
-        .iter()
-        .map(|e| Event {
-            id: e.id,
-            task_id: e.task_id,
-            start_time: Utc.from_utc_datetime(&e.start_time),
-        })
-        .collect();
+    let event = event.map(|e| Event {
+        id: e.id,
+        task_id: e.task_id,
+        start_time: Utc.from_utc_datetime(&e.start_time),
+    });
 
-    Ok(Json(GetEventsResponse { events }))
+    Ok(Json(GetEventResponse { event }))
 }

--- a/protocol/src/events.rs
+++ b/protocol/src/events.rs
@@ -12,6 +12,11 @@ pub struct GetEventsResponse {
     pub events: Vec<Event>,
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct GetEventResponse {
+    pub event: Option<Event>,
+}
+
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct Event {
     pub id: EventId,
@@ -20,6 +25,6 @@ pub struct Event {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct GetDeviceEventsRequest {
+pub struct GetDeviceEventRequest {
     pub device_id: DeviceId,
 }


### PR DESCRIPTION
Updated the endpoint for a device, such that it do not get all events for that device. It should only get the next active event.