### PR TITLE
Added error message in case of overflow.

### DIFF
--- a/backend/benches/benchmark.rs
+++ b/backend/benches/benchmark.rs
@@ -8,7 +8,6 @@ use scheduling_backend::scheduling::{
     scheduler::NaiveSchedulerAlgorithm, task_for_scheduler::TaskForScheduler,
 };
 
-use either::*;
 use protocol::{tasks::TaskId, time::Timespan};
 
 struct TaskFactory {

--- a/backend/src/scheduling/scheduler.rs
+++ b/backend/src/scheduling/scheduler.rs
@@ -143,6 +143,14 @@ fn find_best_event(task: &TaskForScheduler, graph: &DiscreteGraph) -> Result<usi
         timeslot_end,
         task
     );
+    assert!(
+        timeslot_end - timeslot_start >= (timeslots - 1),
+        "Unschedulable task provided, because the duration is larger than the task after truncating, task: {:?} timespan start in timeslots: {}, timespan end in timeslots: {}, duration in timeslots: {}",
+        task,
+        timeslot_start,
+        timeslot_end,
+        timeslots
+    );
 
     // Find the max of mapped_graph slice.
     // Slice is made form the tasks timespan


### PR DESCRIPTION
Added an assert in case the truncation of the task ruins the algorithm, such that an error is provided.
To solve this we should just validate that the task is possible to be scheduled within the day in which we are considering to place the event.