### PR TITLE
Fixed a rounding error in scheduler

### DIFF
--- a/protocol/src/tasks.rs
+++ b/protocol/src/tasks.rs
@@ -9,7 +9,19 @@ use crate::{
 };
 
 #[derive(
-    Deserialize, Serialize, Debug, sqlx::Type, PartialEq, Eq, From, Into, Clone, Copy, Display,
+    Deserialize,
+    Serialize,
+    Debug,
+    sqlx::Type,
+    PartialEq,
+    Eq,
+    From,
+    Into,
+    Clone,
+    Copy,
+    Display,
+    PartialOrd,
+    Ord,
 )]
 #[sqlx(transparent)]
 pub struct TaskId(i64);


### PR DESCRIPTION
This error occurred when the task was made in smaller time deltas than the graph.

This should not be possible because the graph determines our precision and therefore when the task uses higher precision it now returns an error.