### PR TITLE
Remove home address input field from sign up page

### DIFF
--- a/frontend/app/src/main/java/dk/scheduling/schedulingfrontend/pages/SignUpPage.kt
+++ b/frontend/app/src/main/java/dk/scheduling/schedulingfrontend/pages/SignUpPage.kt
@@ -42,9 +42,6 @@ fun SignUpPage(
     var password by remember {
         mutableStateOf("")
     }
-    var homeAddress by remember {
-        mutableStateOf("")
-    }
     var isSignUpFailed by remember {
         mutableStateOf(false)
     }
@@ -77,18 +74,6 @@ fun SignUpPage(
             password,
             onPasswordChange = {
                 password = it
-                if (isSignUpFailed) isSignUpFailed = false
-            },
-            isError = isSignUpFailed,
-        )
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        StandardTextField(
-            label = "Home Address",
-            value = homeAddress,
-            onValueChange = {
-                homeAddress = it
                 if (isSignUpFailed) isSignUpFailed = false
             },
             isError = isSignUpFailed,


### PR DESCRIPTION
The home address input field is not used, not validated, and not sent to the backend.